### PR TITLE
Removing-minio-provisioning

### DIFF
--- a/testops-ldap/docker-compose.yml
+++ b/testops-ldap/docker-compose.yml
@@ -227,18 +227,6 @@ services:
       timeout: 3s
       retries: 30
 
-  minio-provisioning:
-    restart: "no"
-    image: minio/mc
-    container_name: minio-provisioning
-    networks:
-      - allure-net
-    entrypoint: "/bin/sh -c"
-    command: >
-      "mc alias set ${ALLURE_S3_PROVIDER} ${ALLURE_S3_URL} ${ALLURE_S3_ACCESS_KEY} ${ALLURE_S3_SECRET_KEY} --api S3v4 &&
-       mc mb --ignore-existing ${ALLURE_S3_PROVIDER}/${ALLURE_S3_BUCKET} &&
-       mc admin info ${ALLURE_S3_PROVIDER}"
-
   autoheal:
     restart: always
     container_name: autoheal

--- a/testops-oidc/docker-compose.yml
+++ b/testops-oidc/docker-compose.yml
@@ -223,18 +223,6 @@ services:
       timeout: 3s
       retries: 30
 
-  minio-provisioning:
-    restart: "no"
-    image: minio/mc
-    container_name: minio-provisioning
-    networks:
-      - allure-net
-    entrypoint: "/bin/sh -c"
-    command: >
-      "mc alias set ${ALLURE_S3_PROVIDER} ${ALLURE_S3_URL} ${ALLURE_S3_ACCESS_KEY} ${ALLURE_S3_SECRET_KEY} --api S3v4 &&
-       mc mb --ignore-existing ${ALLURE_S3_PROVIDER}/${ALLURE_S3_BUCKET} &&
-       mc admin info ${ALLURE_S3_PROVIDER}"
-
   autoheal:
     restart: always
     container_name: autoheal

--- a/testops/docker-compose.yml
+++ b/testops/docker-compose.yml
@@ -215,18 +215,6 @@ services:
       timeout: 3s
       retries: 30
 
-  minio-provisioning:
-    restart: "no"
-    image: minio/mc
-    container_name: minio-provisioning
-    networks:
-      - allure-net
-    entrypoint: "/bin/sh -c"
-    command: >
-      "mc alias set ${ALLURE_S3_PROVIDER} ${ALLURE_S3_URL} ${ALLURE_S3_ACCESS_KEY} ${ALLURE_S3_SECRET_KEY} --api S3v4 &&
-       mc mb --ignore-existing ${ALLURE_S3_PROVIDER}/${ALLURE_S3_BUCKET} &&
-       mc admin info ${ALLURE_S3_PROVIDER}"
-
   autoheal:
     restart: always
     container_name: autoheal


### PR DESCRIPTION
Signed-off-by: Egor Ivanov <cheshi.mantu@protonmail.com>

removed inio provisioning as this serfvice leads to unnecessary actions which confuse the end user and leading to useless support requetsts